### PR TITLE
Added better support for nested groups, fixes default paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,46 +65,11 @@ Given an input object with complex nested structure, the filter will return:
 
 ## Supported Data Structures
 
-### 1. Simple Properties
-```java
-List<String> paths = List.of("username", "email");
-```
-
-### 2. Nested Objects
-```java
-List<String> paths = List.of("address.street", "address.zipCode");
-```
-
-### 3. Collections and Arrays
-```java
-// Extract from Lists
-List<String> paths = List.of("orders.products.name");
-
-// Extract from Arrays
-List<String> paths = List.of("occupations.title");
-```
-
-### 4. Map Structures
-
-#### Simple Maps
-```java
-// Map<String, String>
-List<String> paths = List.of(
-    "additionalInfo.preferredLanguage",
-    "additionalInfo.subscriptionStatus"
-);
-```
-
-#### Complex Maps
-```java
-// Map<String, Address>
-List<String> paths = List.of(
-    "locations.home.street",
-    "locations.work.city"
-);
-```
-
-### 5. Grouped Paths
+- Simple Properties
+- Nested Objects
+- Collections and Arrays
+- Map Structures
+- Grouped Paths
 
 For scenarios where you need multiple properties from the same parent object, you can use the grouped paths syntax to write more concise filter expressions:
 
@@ -114,35 +79,9 @@ For scenarios where you need multiple properties from the same parent object, yo
 ```
 
 #### Example
-Instead of writing:
-```java
-List<String> paths = List.of(
-    "locations.home.street",
-    "locations.work.city"
-);
-```
-
-You can also write:
 ```java
 List<String> paths = List.of(
     "locations[home.street,work.city]"
-);
-```
-
-#### More Complex Examples
-```java
-// Multiple grouped paths
-List<String> paths = List.of(
-    "locations[home.street,home.zipCode,work.city]",
-    "contact[email,phone.mobile]",
-    "orders[products.name,total,date]"
-);
-
-// Mixed with regular paths
-List<String> paths = List.of(
-    "username",                           // Regular path
-    "locations[home.street,work.city]",   // Grouped path
-    "address.state"                       // Regular path
 );
 ```
 
@@ -150,79 +89,6 @@ List<String> paths = List.of(
 The grouped paths are automatically expanded internally:
 - `"locations[home.street,work.city]"` becomes `"locations.home.street"` and `"locations.work.city"`
 - `"contact[email,phone.mobile]"` becomes `"contact.email"` and `"contact.phone.mobile"`
-
-This feature maintains full backward compatibility while providing a more readable way to specify multiple related paths.
-
-## Advanced Examples
-
-### Complex Nested Filtering
-
-```java
-UserDetail user = UserDetail.of(); // Creates sample data
-
-List<String> filterPaths = List.of(
-    "username",                          // Simple property
-    "address.street",                    // Nested object
-    "orders.products.name",              // Collection of objects
-    "orders.products.description",       // Multiple properties from same collection
-    "additionalInfo.preferredLanguage",  // Simple Map value
-    "locations.home.street",             // Complex Map value
-    "occupations.title"                  // Array of objects
-);
-
-Map<String, Object> filtered = filterUtil.filter(user, filterPaths);
-```
-
-### Result Structure
-
-The above filtering would produce:
-
-```json
-{
-  "username": "john_doe",
-  "address": {
-    "street": "123 Main St"
-  },
-  "orders": [
-    {
-      "products": [
-        {
-          "name": "Laptop",
-          "description": "High-end gaming laptop"
-        },
-        {
-          "name": "Smartphone", 
-          "description": "Latest model smartphone"
-        }
-      ]
-    },
-    {
-      "products": [
-        {
-          "name": "Headphones",
-          "description": "Noise-cancelling headphones"
-        }
-      ]
-    }
-  ],
-  "additionalInfo": {
-    "preferredLanguage": "English"
-  },
-  "locations": {
-    "home": {
-      "street": "456 Elm St"
-    }
-  },
-  "occupations": [
-    {
-      "title": "Software Engineer"
-    },
-    {
-      "title": "Project Manager"
-    }
-  ]
-}
-```
 
 ## How It Works
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.trackerforce</groupId>
     <artifactId>dot-path-ql</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
 
     <name>dot-path-ql</name>
     <description>dotPathQL allows object attribute filtering</description>
@@ -50,7 +50,7 @@
         <junit-jupiter.version>5.13.4</junit-jupiter.version>
         <lombok.version>1.18.30</lombok.version>
 
-        <!-- Plugins -->
+        <!-- plugins -->
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
@@ -63,6 +63,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>

--- a/src/test/java/io/github/trackerforce/TypeClassTest.java
+++ b/src/test/java/io/github/trackerforce/TypeClassTest.java
@@ -1,42 +1,16 @@
 package io.github.trackerforce;
 
-import io.github.trackerforce.fixture.clazz.Customer;
+import io.github.trackerforce.fixture.clazz.customer.Customer;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@SuppressWarnings("unchecked")
-class DotPathQLClassTest {
+class TypeClassTest {
 
 	DotPathQL dotPathQL = new DotPathQL();
-
-	@Test
-	void shouldReturnFilteredObjectAttributes() {
-		// Given
-		var customer = Customer.of();
-		var filterPaths = List.of(
-			"name",
-			"features.name"
-		);
-
-		// When
-		var result = dotPathQL.filter(customer, filterPaths);
-
-		// Then
-		assertEquals(2, result.size());
-		assertEquals("Default Name", result.get("name"));
-
-		// Verify nested features structure
-		var features = dotPathQL.listFrom(result, "features");
-		assertNotNull(features);
-		assertEquals(2, features.size());
-		assertEquals("Default Feature", features.get(0).get("name"));
-		assertEquals("Additional Feature", features.get(1).get("name"));
-	}
 
 	@Test
 	void shouldReturnFilteredObjectPrivateAttributes() {
@@ -60,9 +34,10 @@ class DotPathQLClassTest {
 		assertEquals("securePassword", metadata.get("password"));
 
 		assertNotNull(metadata.get("tags"));
-		assertEquals(2, ((String[]) metadata.get("tags")).length);
-		assertEquals("tag1", ((String[]) metadata.get("tags"))[0]);
-		assertEquals("tag2", ((String[]) metadata.get("tags"))[1]);
+		var tags = dotPathQL.arrayFrom(metadata, "tags");
+		assertEquals(2, tags.length);
+		assertEquals("tag1", tags[0]);
+		assertEquals("tag2", tags[1]);
 	}
 
 	@Test
@@ -81,12 +56,11 @@ class DotPathQLClassTest {
 		assertNotNull(features);
 
 		assertEquals(1, features.size());
-		var metadata = (List<Object>) features.get(0).get("metadata");
+		var metadata = dotPathQL.listFrom(features.get(0), "metadata");
 		assertNotNull(metadata);
 
 		assertEquals(2, metadata.size());
-		assertEquals("defaultTag", ((String[]) ((Map<String, Object>) metadata.get(0)).get("tags"))[0]);
-		assertEquals("anotherTag", ((String[])((Map<String, Object>) metadata.get(1)).get("tags"))[0]);
-
+		assertEquals("defaultTag", dotPathQL.arrayFrom(metadata.get(0), "tags")[0]);
+		assertEquals("anotherTag", dotPathQL.arrayFrom(metadata.get(1), "tags")[0]);
 	}
 }

--- a/src/test/java/io/github/trackerforce/fixture/clazz/Address.java
+++ b/src/test/java/io/github/trackerforce/fixture/clazz/Address.java
@@ -1,0 +1,17 @@
+package io.github.trackerforce.fixture.clazz;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@AllArgsConstructor
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+public class Address {
+	String street;
+	String city;
+	String state;
+	String zipCode;
+	String country;
+}

--- a/src/test/java/io/github/trackerforce/fixture/clazz/Occupation.java
+++ b/src/test/java/io/github/trackerforce/fixture/clazz/Occupation.java
@@ -1,0 +1,17 @@
+package io.github.trackerforce.fixture.clazz;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@AllArgsConstructor
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+public class Occupation {
+	String title;
+	String description;
+	double salary;
+	String department;
+	int yearsOfExperience;
+}

--- a/src/test/java/io/github/trackerforce/fixture/clazz/Order.java
+++ b/src/test/java/io/github/trackerforce/fixture/clazz/Order.java
@@ -1,0 +1,17 @@
+package io.github.trackerforce.fixture.clazz;
+
+import java.util.Date;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@AllArgsConstructor
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+public class Order {
+	List<Product> products;
+	Date orderDate;
+	String orderId;
+}

--- a/src/test/java/io/github/trackerforce/fixture/clazz/Product.java
+++ b/src/test/java/io/github/trackerforce/fixture/clazz/Product.java
@@ -1,0 +1,18 @@
+package io.github.trackerforce.fixture.clazz;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@AllArgsConstructor
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+public class Product {
+	String id;
+	String name;
+	String description;
+	double price;
+	String category;
+	int stockQuantity;
+}

--- a/src/test/java/io/github/trackerforce/fixture/clazz/UserDetail.java
+++ b/src/test/java/io/github/trackerforce/fixture/clazz/UserDetail.java
@@ -1,0 +1,72 @@
+package io.github.trackerforce.fixture.clazz;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@AllArgsConstructor
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+public class UserDetail {
+	String username;
+	String email;
+	String fullName;
+	String phoneNumber;
+	Address address;
+	List<Order> orders;
+	String[] roles;
+	Occupation[] occupations;
+	Map<String, String> additionalInfo;
+	Map<String, Address> locations;
+
+	public static UserDetail of() {
+		return new UserDetail(
+				"john_doe",
+				"jown@email.com",
+				"John Doe",
+				"+1234567890",
+				new Address(
+						"123 Main St",
+						"Springfield",
+						"IL",
+						"62701",
+						"USA"
+				),
+				List.of(
+						new Order(
+								List.of(
+										new Product("1", "Laptop", "High-end gaming laptop", 1500.00, "Electronics", 5),
+										new Product("2", "Smartphone", "Latest model smartphone", 800.00, "Electronics", 10)
+								),
+								new Date(),
+								"order123"
+						),
+						new Order(
+								List.of(
+										new Product("3", "Headphones", "Noise-cancelling headphones", 200.00, "Accessories", 15)
+								),
+								new Date(),
+								"order456"
+						)
+				),
+				new String[] {"USER", "ADMIN"},
+				new Occupation[] {
+						new Occupation("Software Engineer", "Develops software applications", 90000.00, "Engineering", 5),
+						new Occupation("Project Manager", "Manages software projects", 95000.00, "Management", 7)
+				},
+				Map.of(
+						"preferredLanguage", "English",
+						"subscriptionStatus", "Active",
+						"lastLogin", "2023-10-01T12:00:00Z"
+				),
+				Map.of(
+						"home", new Address("456 Elm St", "Springfield", "IL", "62701", "USA"),
+						"work", new Address("789 Oak St", "Springfield", "IL", "62701", "USA")
+				)
+		);
+	}
+}

--- a/src/test/java/io/github/trackerforce/fixture/clazz/customer/Customer.java
+++ b/src/test/java/io/github/trackerforce/fixture/clazz/customer/Customer.java
@@ -1,4 +1,4 @@
-package io.github.trackerforce.fixture.clazz;
+package io.github.trackerforce.fixture.clazz.customer;
 
 import lombok.Data;
 

--- a/src/test/java/io/github/trackerforce/fixture/clazz/customer/Feature.java
+++ b/src/test/java/io/github/trackerforce/fixture/clazz/customer/Feature.java
@@ -1,4 +1,4 @@
-package io.github.trackerforce.fixture.clazz;
+package io.github.trackerforce.fixture.clazz.customer;
 
 import lombok.Data;
 

--- a/src/test/java/io/github/trackerforce/fixture/clazz/customer/Metadata.java
+++ b/src/test/java/io/github/trackerforce/fixture/clazz/customer/Metadata.java
@@ -1,4 +1,4 @@
-package io.github.trackerforce.fixture.clazz;
+package io.github.trackerforce.fixture.clazz.customer;
 
 import lombok.Setter;
 


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings to the dotPathQL filtering library, with a focus on improved support for complex and nested grouped paths, better test coverage, and minor codebase cleanups. The most significant change is the expansion of grouped path syntax to support nested brackets, making it possible to concisely specify deeply nested properties for filtering. The test suite is also refactored to use parameterized tests, ensuring consistent behavior for both record and class-based models.

### Grouped Path Expansion and Nested Structure Support
* Added support for nested grouped paths in filter expressions (e.g., `"locations[home[street],work[city]]"`), including robust parsing and recursive expansion logic in `DotPathQL.java`. This greatly improves the flexibility of property filtering for complex object graphs.
* Refactored the grouped path expansion logic to handle nested brackets, including new helper methods like `findMatchingClosingBracket`, `parseGroupedContent`, `expandNestedSubPath`, and `parseCommaSeparatedPaths` for reliable parsing.

### API Enhancements
* Added the `arrayFrom` method to `DotPathQL` to support extraction of arrays of objects from filtered results, complementing existing `mapFrom` and `listFrom` methods.
* Unified null and key existence checks for map extraction into a new `isInvalid` helper method, simplifying validation throughout the codebase. [[1]](diffhunk://#diff-482569c6ed3a9ada4808cf01bb7056a5e3ce0e2c59138a78af44c9178e40a020L58-R58) [[2]](diffhunk://#diff-482569c6ed3a9ada4808cf01bb7056a5e3ce0e2c59138a78af44c9178e40a020R435-R438)

### Filtering Logic Improvements
* Improved handling of nested structures in filtering, ensuring that existing nested maps are not overwritten and that empty maps are removed from results for collections and arrays. [[1]](diffhunk://#diff-482569c6ed3a9ada4808cf01bb7056a5e3ce0e2c59138a78af44c9178e40a020L164-R332) [[2]](diffhunk://#diff-482569c6ed3a9ada4808cf01bb7056a5e3ce0e2c59138a78af44c9178e40a020L196-R354) [[3]](diffhunk://#diff-482569c6ed3a9ada4808cf01bb7056a5e3ce0e2c59138a78af44c9178e40a020L208)
* Changed the order of filter path expansion so that default filter paths are prepended to user-supplied paths, ensuring consistent inclusion of defaults.

### Test Suite Refactoring
* Refactored and renamed the main test class to `TypeClassRecordTest`, converting all tests to parameterized tests using JUnit Jupiter. This ensures that both record and class-based models are tested for identical filtering behavior. [[1]](diffhunk://#diff-34da150aaa60a5ffc762e892c70262e3d7fc3833777bd2253fb3212ac55711bfL3-L18) [[2]](diffhunk://#diff-34da150aaa60a5ffc762e892c70262e3d7fc3833777bd2253fb3212ac55711bfL59-L62) [[3]](diffhunk://#diff-34da150aaa60a5ffc762e892c70262e3d7fc3833777bd2253fb3212ac55711bfL80-L83) [[4]](diffhunk://#diff-34da150aaa60a5ffc762e892c70262e3d7fc3833777bd2253fb3212ac55711bfL102-L105) [[5]](diffhunk://#diff-34da150aaa60a5ffc762e892c70262e3d7fc3833777bd2253fb3212ac55711bfL131-L134)
* Added the `junit-jupiter-params` dependency to `pom.xml` to support parameterized testing.

### Documentation and Build Updates
* Simplified and reorganized documentation in `README.md` to present supported data structures more concisely, and removed redundant advanced examples for clarity. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-R72) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L117-L226)
* Updated the Maven project version to `1.0.1-SNAPSHOT` and made minor formatting improvements in the `pom.xml` file. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L9-R9) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L53-R53)