### PR TITLE
Added support to defaultPaths for the exclude API

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The `DotPathQL` is the core component of this project that allows you to extract
 - 📋 **Collection Handling**: Process Lists, Arrays, and other Collections
 - 🗺️ **Map Support**: Handle both simple and complex Map structures
 - 📝 **Record & POJO Support**: Works with Java Records and traditional classes
-- 🔒 **Private Field Access**: Can access private fields when getters aren't available
+- 🔒 **Private Field Access**: Can access private fields when getters aren't available (filtering only)
 - 🚀 **Performance Optimized**: Efficient reflection-based property access
 
 ## Quick Start
@@ -38,10 +38,8 @@ The `DotPathQL` is the core component of this project that allows you to extract
 ### Filter Usage
 
 ```java
-DotPathQL filterUtil = new DotPathQL();
-
 // Filter specific properties from an object
-Map<String, Object> result = filterUtil.filter(userObject, List.of(
+Map<String, Object> result = new DotPathQL().filter(userObject, List.of(
     "username",
     "address.street",
     "address.city"
@@ -51,10 +49,8 @@ Map<String, Object> result = filterUtil.filter(userObject, List.of(
 ### Exclude Usage
 
 ```java
-DotPathQL filterUtil = new DotPathQL();
-
 // Exclude specific properties and return everything else
-Map<String, Object> result = filterUtil.exclude(userObject, List.of(
+Map<String, Object> result = new DotPathQL().exclude(userObject, List.of(
     "password",
     "ssn",
     "address.country"
@@ -63,7 +59,7 @@ Map<String, Object> result = filterUtil.exclude(userObject, List.of(
 
 ## Supported Data Structures
 
-- Simple Properties
+- Simple Properties (primitive and object types)
 - Nested Objects
 - Collections and Arrays
 - Map Structures
@@ -96,7 +92,7 @@ The utility uses a multi-layered approach to access object properties:
 
 1. **Record Components** (Most Efficient): For Java Records, uses the generated accessor methods
 2. **Getter Methods**: Tries standard getter methods (`getName()`, `getAddress()`)
-3. **Direct Field Access**: Falls back to direct field access for private fields
+3. **Direct Field Access**: Falls back to direct field access for private fields (except for the exclude API)
 
 ### Nested Structure Processing
 
@@ -176,6 +172,25 @@ List<String> reportFields = List.of(
     "orders.date",
     "orders.products.category"
 );
+```
+
+## Helper Utilities
+
+You can also easy access the map result using the `DotPathQL` utility methods:
+
+```java
+// Step 1
+var dotPathQL = new DotPathQL();
+var result = dotPathQL.filter(userObject, List.of(
+    "address",
+    "friendList",
+    "games"
+));
+
+// Step 2: Accessing the result
+var address = dotPathQL.mapFrom(result, "address");
+var friendList = dotPathQL.listFrom(result, "friendList");
+var games = dotPathQL.arrayFrom(result, "games");
 ```
 
 ## Technical Requirements

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.trackerforce</groupId>
     <artifactId>dot-path-ql</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <name>dot-path-ql</name>
     <description>dotPathQL allows object attribute filtering</description>

--- a/src/main/java/io/github/trackerforce/DotPathQL.java
+++ b/src/main/java/io/github/trackerforce/DotPathQL.java
@@ -14,8 +14,8 @@ import java.util.Map;
 @SuppressWarnings("unchecked")
 public class DotPathQL {
 
-	private final PathFilter pathFilter;
-	private final PathExclude pathExclude;
+	private final PathCommon pathFilter;
+	private final PathCommon pathExclude;
 
 	/**
 	 * Constructs a DotPathQL instance with an empty list of default filter paths.
@@ -36,7 +36,7 @@ public class DotPathQL {
 	 * @return a map containing the filtered properties
 	 */
 	public <T> Map<String, Object> filter(T source, List<String> filterPaths) {
-		return pathFilter.filter(source, filterPaths);
+		return pathFilter.run(source, filterPaths);
 	}
 
 	/**
@@ -51,7 +51,7 @@ public class DotPathQL {
 	 * @return a map containing all properties except the excluded ones
 	 */
 	public <T> Map<String, Object> exclude(T source, List<String> excludePaths) {
-		return pathExclude.exclude(source, excludePaths);
+		return pathExclude.run(source, excludePaths);
 	}
 
 	/**
@@ -108,7 +108,16 @@ public class DotPathQL {
 	 * @param paths the list of default filter paths to add
 	 */
 	public void addDefaultFilterPaths(List<String> paths) {
-		pathFilter.addDefaultFilterPaths(paths);
+		pathFilter.addDefaultPaths(paths);
+	}
+
+	/**
+	 * Adds default exclude paths that will be included in every exclusion operation.
+	 *
+	 * @param paths the list of default exclude paths to add
+	 */
+	public void addDefaultExcludePaths(List<String> paths) {
+		pathExclude.addDefaultPaths(paths);
 	}
 
 	private boolean isInvalid(Map<String, Object> source, String property) {

--- a/src/main/java/io/github/trackerforce/PathCommon.java
+++ b/src/main/java/io/github/trackerforce/PathCommon.java
@@ -4,7 +4,9 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Common functionality for handling paths in the DotPathQL library.
@@ -14,28 +16,52 @@ import java.util.List;
 abstract class PathCommon {
 
 	/**
-	 * Default filter paths that can be used across different implementations.
-	 * This allows for easy configuration of common paths to filter.
+	 * Default paths that can be used across different implementations.
 	 */
-	protected final List<String> defaultFilterPaths;
+	protected final List<String> defaultPaths;
 
 	/**
-	 * Constructor to initialize the PathCommon with an empty list of default filter paths.
-	 * This allows subclasses to add their own default paths as needed.
+	 * Executes the path processing logic for the given source object.
+	 *
+	 * @param <T>         the type of the source object
+	 * @param source      the source object to process
+	 * @param filterPaths the list of paths to filter or exclude
+	 * @return a map containing the processed properties
 	 */
-	protected PathCommon() {
-		this.defaultFilterPaths = new ArrayList<>();
+	abstract <T> Map<String, Object> execute(T source, List<String> filterPaths);
+
+	/**
+	 * Runs the path processing logic for the given source object with the specified paths.
+	 *
+	 * @param <T>          the type of the source object
+	 * @param source       the source object to process
+	 * @param excludePaths the list of paths to exclude
+	 * @return a map containing the processed properties
+	 */
+	<T> Map<String, Object> run(T source, List<String> excludePaths) {
+		if (source == null) {
+			return Collections.emptyMap();
+		}
+
+		return execute(source, expandGroupedPaths(excludePaths));
 	}
 
 	/**
-	 * Adds default filter paths to the list of paths that can be used
-	 * when filtering objects. This allows for easy configuration of common
-	 * paths that should always be available for filtering.
-	 *
-	 * @param paths the list of paths to add as default filter paths
+	 * Constructor to initialize the PathCommon with an empty list of default paths.
+	 * This allows subclasses to add their own default paths as needed.
 	 */
-	public void addDefaultFilterPaths(List<String> paths) {
-		defaultFilterPaths.addAll(paths);
+	protected PathCommon() {
+		this.defaultPaths = new ArrayList<>();
+	}
+
+	/**
+	 * Adds default paths to the list of paths that can be used
+	 * when processing objects.
+	 *
+	 * @param paths the list of paths to add as default paths
+	 */
+	public void addDefaultPaths(List<String> paths) {
+		defaultPaths.addAll(paths);
 	}
 
 	/**

--- a/src/main/java/io/github/trackerforce/PathExclude.java
+++ b/src/main/java/io/github/trackerforce/PathExclude.java
@@ -10,13 +10,11 @@ class PathExclude extends PathCommon {
 		INSTANCE
 	}
 
-	public <T> Map<String, Object> exclude(T source, List<String> excludePaths) {
-		if (source == null) {
-			return Collections.emptyMap();
-		}
-
-		ExclusionNode root = buildExclusionTree(expandGroupedPaths(excludePaths));
+	public <T> Map<String, Object> execute(T source, List<String> excludePaths) {
 		Map<String, Object> result = new LinkedHashMap<>();
+		excludePaths.addAll(0, defaultPaths);
+
+		ExclusionNode root = buildExclusionTree(excludePaths);
 		buildExcluding(result, source, "", root);
 		return result;
 	}

--- a/src/main/java/io/github/trackerforce/PathFilter.java
+++ b/src/main/java/io/github/trackerforce/PathFilter.java
@@ -5,16 +5,11 @@ import java.util.*;
 @SuppressWarnings("unchecked")
 class PathFilter extends PathCommon {
 
-	public <T> Map<String, Object> filter(T source, List<String> filterPaths) {
-		if (source == null) {
-			return Collections.emptyMap();
-		}
-
+	public <T> Map<String, Object> execute(T source, List<String> filterPaths) {
 		Map<String, Object> result = new LinkedHashMap<>();
-		List<String> expandedPaths = expandGroupedPaths(filterPaths);
-		expandedPaths.addAll(0, defaultFilterPaths);
+		filterPaths.addAll(0, defaultPaths);
 
-		for (String path : expandedPaths) {
+		for (String path : filterPaths) {
 			addPathToResult(result, source, path);
 		}
 

--- a/src/test/java/io/github/trackerforce/ExcludeTypeClassRecordTest.java
+++ b/src/test/java/io/github/trackerforce/ExcludeTypeClassRecordTest.java
@@ -106,6 +106,21 @@ class ExcludeTypeClassRecordTest {
         assertFalse(work.containsKey("city"));
     }
 
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("userDetailProvider")
+	void shouldAddDefaultExclusionPaths(String implementation, Object userDetail) {
+		// When
+		dotPathQL.addDefaultExcludePaths(List.of("username"));
+		var result = dotPathQL.exclude(userDetail, List.of("address.city"));
+
+		// Then
+		assertFalse(result.containsKey("username"));
+		var address = dotPathQL.mapFrom(result, "address");
+		assertNotNull(address);
+		assertFalse(address.containsKey("city"));
+		assertTrue(address.containsKey("street"));
+	}
+
 	@Test
 	void shouldReturnEmptyMapWhenSourceIsNull() {
 		// When

--- a/src/test/java/io/github/trackerforce/FilterTypeClassRecordTest.java
+++ b/src/test/java/io/github/trackerforce/FilterTypeClassRecordTest.java
@@ -126,13 +126,9 @@ class FilterTypeClassRecordTest {
 	@ParameterizedTest(name = "{0}")
 	@MethodSource("userDetailProvider")
 	void shouldAddDefaultFilterPaths(String implementation, Object userDetail) {
-		// Given
-		var defaultPaths = List.of("username");
-		var filterPaths = List.of("address.city");
-
 		// When
-		dotPathQL.addDefaultFilterPaths(defaultPaths);
-		var result = dotPathQL.filter(userDetail, filterPaths);
+		dotPathQL.addDefaultFilterPaths(List.of("username"));
+		var result = dotPathQL.filter(userDetail, List.of("address.city"));
 
 		// Then
 		assertEquals(2, result.size());


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the DotPathQL library, focusing on simplifying the API, unifying the internal path handling logic, and enhancing usability. The main changes include consolidating filter and exclude logic under a common base class, updating method names for clarity, and adding support for default exclude paths. The documentation and tests have also been updated to reflect these changes.

**API and Internal Refactoring**
* Unified the filter and exclude logic by introducing a new `PathCommon` base class, replacing separate `PathFilter` and `PathExclude` references in `DotPathQL` with `PathCommon` instances, and standardizing the internal method names to `run` and `execute` for both filtering and exclusion operations. (`src/main/java/io/github/trackerforce/DotPathQL.java`, `src/main/java/io/github/trackerforce/PathCommon.java`, [[1]](diffhunk://#diff-482569c6ed3a9ada4808cf01bb7056a5e3ce0e2c59138a78af44c9178e40a020L17-R18) [[2]](diffhunk://#diff-482569c6ed3a9ada4808cf01bb7056a5e3ce0e2c59138a78af44c9178e40a020L39-R39) [[3]](diffhunk://#diff-482569c6ed3a9ada4808cf01bb7056a5e3ce0e2c59138a78af44c9178e40a020L54-R54) [[4]](diffhunk://#diff-a22baef63276093cbf59c9c8d1bff3bc532ee714d01fd68f37918b9aa081cf55L17-R64) [[5]](diffhunk://#diff-7ef09e3309a7769fdf454bf832d8c1eca150192ff68bba789253643edd3f4101L13-R17) [[6]](diffhunk://#diff-e6d56bef71d2bf735ba06272561909791ad846d38e62c6bd853b0bfc186dd75bL8-R12)

**Default Path Management**
* Added support for default exclude paths via the new `addDefaultExcludePaths` method in `DotPathQL`, allowing users to specify paths that are always excluded in exclusion operations, similar to the existing default filter paths. (`src/main/java/io/github/trackerforce/DotPathQL.java`, [src/main/java/io/github/trackerforce/DotPathQL.javaL111-R120](diffhunk://#diff-482569c6ed3a9ada4808cf01bb7056a5e3ce0e2c59138a78af44c9178e40a020L111-R120))
* Updated the internal logic so both filter and exclude operations prepend their respective default paths to the user-provided paths, ensuring consistent behavior. (`src/main/java/io/github/trackerforce/PathCommon.java`, [[1]](diffhunk://#diff-a22baef63276093cbf59c9c8d1bff3bc532ee714d01fd68f37918b9aa081cf55L17-R64) [[2]](diffhunk://#diff-7ef09e3309a7769fdf454bf832d8c1eca150192ff68bba789253643edd3f4101L13-R17) [[3]](diffhunk://#diff-e6d56bef71d2bf735ba06272561909791ad846d38e62c6bd853b0bfc186dd75bL8-R12)

**Documentation Updates**
* Revised the `README.md` to clarify the behavior of private field access, update code examples to use the simplified API, document the new helper utilities, and specify supported data structures more clearly. (`README.md`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R21) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-R42) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L54-R53) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L66-R62) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L99-R95) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R177-R195)

**Testing Enhancements**
* Added and updated tests to verify the new default exclude paths functionality and ensure correct results when default paths are used for both filtering and exclusion. (`src/test/java/io/github/trackerforce/ExcludeTypeClassRecordTest.java`, `src/test/java/io/github/trackerforce/FilterTypeClassRecordTest.java`, [[1]](diffhunk://#diff-a8813264fc411429a4b8cda31725a1391b954ecf921332be6bcfe237d47b444cR109-R123) [[2]](diffhunk://#diff-ecbb9defa2c7569a9f384b6890e59fa9e67b1c156ce46aa5c51e81408b89a74fL129-R131)

**Version Bump**
* Updated the project version to `1.1.0-SNAPSHOT` to reflect these feature additions and API changes. (`pom.xml`, [pom.xmlL9-R9](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L9-R9))