### PR TITLE
Improved DotUtils for better type handling

### DIFF
--- a/src/main/java/ca/trackerforce/DotUtils.java
+++ b/src/main/java/ca/trackerforce/DotUtils.java
@@ -2,6 +2,7 @@ package ca.trackerforce;
 
 import ca.trackerforce.path.DotPathFactory;
 
+import java.lang.reflect.Array;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -33,11 +34,13 @@ public class DotUtils {
 	 * @throws ClassCastException if the property is not a map
 	 */
 	public static Map<String, Object> mapFrom(Map<String, Object> source, String property) {
-		if (isInvalid(source, property)) {
+		Object result = getObjectFromSource(source, property);
+
+		if (!(result instanceof Map)) {
 			return Collections.emptyMap();
 		}
 
-		return (Map<String, Object>) source.get(property);
+		return (Map<String, Object>) result;
 	}
 
 	/**
@@ -49,31 +52,84 @@ public class DotUtils {
 	 * @throws ClassCastException if the property is not a list of maps
 	 */
 	public static List<Map<String, Object>> listFrom(Map<String, Object> source, String property) {
-		if (isInvalid(source, property)) {
+		Object result = getObjectFromSource(source, property);
+
+		if (!(result instanceof List)) {
 			return Collections.emptyList();
 		}
 
-		return (List<Map<String, Object>>) source.get(property);
+		return (List<Map<String, Object>>) result;
+	}
+
+	/**
+	 * Extracts a typed list from the source map based on the specified property.
+	 *
+	 * @param source   the source map
+	 * @param property the property to extract or a dot-notated path for nested properties
+	 * @return the extracted list of maps or an empty list if not found
+	 * @throws ClassCastException if the property is not a list of maps
+	 */
+	public static <T> List<T> listFrom(Map<String, Object> source, String property, Class<T> clazz) {
+		Object result = getObjectFromSource(source, property);
+
+		if (!(result instanceof List) || ((List<?>) result).isEmpty() || !clazz.isInstance(((List<?>) result).get(0))) {
+			return Collections.emptyList();
+		}
+
+		return (List<T>) result;
 	}
 
 	/**
 	 * Extracts a list of objects from the source map based on the specified property.
 	 *
 	 * @param source   the source map
-	 * @param property the property to extract
+	 * @param property the property to extract or a dot-notated path for nested properties
 	 * @return the extracted list of objects or an empty list if not found
 	 * @throws ClassCastException if the property is not a list of objects
 	 */
 	public static Object[] arrayFrom(Map<String, Object> source, String property) {
-		if (isInvalid(source, property)) {
+		Object result = getObjectFromSource(source, property);
+
+		if (result == null || !result.getClass().isArray()) {
 			return new Object[0];
 		}
 
-		return (Object[]) source.get(property);
+		return convertToObjectArray(result);
 	}
 
-	private static boolean isInvalid(Map<String, Object> source, String property) {
-		return source == null || property == null || property.isEmpty() || !source.containsKey(property);
+	private static Object getObjectFromSource(Map<String, Object> source, String property) {
+		if (property.contains(".")) {
+			String[] keys = property.split("\\.");
+
+			for (int i = 0; i < keys.length - 1; i++) {
+				source = (Map<String, Object>) source.get(keys[i]);
+			}
+
+			return source.get(keys[keys.length - 1]);
+		}
+
+		if (source == null || !source.containsKey(property)) {
+			return null;
+		}
+
+		return source.get(property);
+	}
+
+	private static Object[] convertToObjectArray(Object array) {
+		Class<?> componentType = array.getClass().getComponentType();
+
+		if (!componentType.isPrimitive()) {
+			return (Object[]) array;
+		}
+
+		int length = Array.getLength(array);
+		Object[] result = new Object[length];
+
+		for (int i = 0; i < length; i++) {
+			result[i] = Array.get(array, i);
+		}
+
+		return result;
 	}
 }
 

--- a/src/main/java/ca/trackerforce/path/PathCommon.java
+++ b/src/main/java/ca/trackerforce/path/PathCommon.java
@@ -100,6 +100,11 @@ abstract class PathCommon implements DotPath {
 				return getterResult;
 			}
 
+			// Try mapping method for Map instances
+			if (source instanceof Map<?, ?> map && map.containsKey(propertyName)) {
+				return map.get(propertyName);
+			}
+
 			// Fall back to direct field access
 			return tryDirectFieldAccess(source, propertyName, clazz);
 		} catch (Exception e) {

--- a/src/test/java/ca/trackerforce/DotUtilsTest.java
+++ b/src/test/java/ca/trackerforce/DotUtilsTest.java
@@ -1,6 +1,5 @@
 package ca.trackerforce;
 
-import ca.trackerforce.fixture.record.UserDetail;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -17,7 +16,7 @@ class DotUtilsTest {
 
 	static Stream<Arguments> userDetailProvider() {
 		return Stream.of(
-				Arguments.of("Record type", UserDetail.of()),
+				Arguments.of("Record type", ca.trackerforce.fixture.record.UserDetail.of()),
 				Arguments.of("Class type", ca.trackerforce.fixture.clazz.UserDetail.of())
 		);
 	}
@@ -27,13 +26,19 @@ class DotUtilsTest {
 	void shouldReturnSelectedArrayProperties(String implementation, Object userDetail) {
 		// When
 		var result = dotPathQL.toMap(userDetail);
-		var roles = DotUtils.arrayFrom(result, "roles");
+		var roles = DotUtils.arrayFrom(result, "roles"); // simple array
+		var locationsHomeCoordinates = DotUtils.arrayFrom(result, "locations.home.coordinates"); // nested array
 
 		// Then
 		assertNotNull(roles);
 		assertEquals(2, roles.length);
 		assertEquals("USER", roles[0]);
 		assertEquals("ADMIN", roles[1]);
+
+		assertNotNull(locationsHomeCoordinates);
+		assertEquals(2, locationsHomeCoordinates.length);
+		assertEquals(39, locationsHomeCoordinates[0]);
+		assertEquals(89, locationsHomeCoordinates[1]);
 	}
 
 	@ParameterizedTest(name = "{0}")
@@ -42,10 +47,16 @@ class DotUtilsTest {
 		// When
 		var result = dotPathQL.toMap(userDetail);
 		var occupations = DotUtils.listFrom(result, "occupations");
+		var locationsWorkNumbers = DotUtils.listFrom(result, "locations.work.numbers", Integer.class);
 
 		// Then
 		assertNotNull(occupations);
 		assertEquals(2, occupations.size());
+
+		assertNotNull(locationsWorkNumbers);
+		assertEquals(5, locationsWorkNumbers.size());
+		assertEquals(11, locationsWorkNumbers.get(0));
+		assertEquals(15, locationsWorkNumbers.get(4));
 	}
 
 	@ParameterizedTest(name = "{0}")

--- a/src/test/java/ca/trackerforce/ExcludeTypeClassRecordTest.java
+++ b/src/test/java/ca/trackerforce/ExcludeTypeClassRecordTest.java
@@ -1,6 +1,5 @@
 package ca.trackerforce;
 
-import ca.trackerforce.fixture.record.UserDetail;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -17,7 +16,7 @@ class ExcludeTypeClassRecordTest {
 
     static Stream<Arguments> userDetailProvider() {
         return Stream.of(
-                Arguments.of("Record type", UserDetail.of()),
+                Arguments.of("Record type", ca.trackerforce.fixture.record.UserDetail.of()),
                 Arguments.of("Class type", ca.trackerforce.fixture.clazz.UserDetail.of())
         );
     }

--- a/src/test/java/ca/trackerforce/FilterTypeClassRecordTest.java
+++ b/src/test/java/ca/trackerforce/FilterTypeClassRecordTest.java
@@ -1,6 +1,5 @@
 package ca.trackerforce;
 
-import ca.trackerforce.fixture.record.UserDetail;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -17,7 +16,7 @@ class FilterTypeClassRecordTest {
 
 	static Stream<Arguments> userDetailProvider() {
 		return Stream.of(
-				Arguments.of("Record type", UserDetail.of()),
+				Arguments.of("Record type", ca.trackerforce.fixture.record.UserDetail.of()),
 				Arguments.of("Class type", ca.trackerforce.fixture.clazz.UserDetail.of())
 		);
 	}
@@ -187,6 +186,24 @@ class FilterTypeClassRecordTest {
 
 	@ParameterizedTest(name = "{0}")
 	@MethodSource("userDetailProvider")
+	void shouldReturnFilteredMapAttributes(String implementation, Object userDetail) {
+		// When
+		var source = dotPathQL.toMap(userDetail); // Convert to Map for testing
+		var result = dotPathQL.filter(source, List.of(
+				"username",
+				"address.street",
+				"orders.products.name"
+		));
+
+		// Then
+		assertEquals(3, result.size());
+		assertEquals("john_doe", result.get("username"));
+		assertEquals(1, DotUtils.mapFrom(result, "address").size());
+		assertEquals(2, DotUtils.listFrom(result, "orders").size());
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("userDetailProvider")
 	void shouldReturnEmptyResultInvalidGroupedPaths(String implementation, Object userDetail) {
 		// When
 		var result = dotPathQL.filter(userDetail, List.of("locations]home[")); // Invalid grouped path
@@ -204,4 +221,5 @@ class FilterTypeClassRecordTest {
 		assertNotNull(result);
 		assertTrue(result.isEmpty());
 	}
+
 }

--- a/src/test/java/ca/trackerforce/PrintTypeClassRecordTest.java
+++ b/src/test/java/ca/trackerforce/PrintTypeClassRecordTest.java
@@ -1,6 +1,5 @@
 package ca.trackerforce;
 
-import ca.trackerforce.fixture.record.UserDetail;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -18,7 +17,7 @@ class PrintTypeClassRecordTest {
 
 	static Stream<Arguments> userDetailProvider() {
 		return Stream.of(
-				Arguments.of("Record type", UserDetail.of()),
+				Arguments.of("Record type", ca.trackerforce.fixture.record.UserDetail.of()),
 				Arguments.of("Class type", ca.trackerforce.fixture.clazz.UserDetail.of())
 		);
 	}


### PR DESCRIPTION
This pull request refactors and enhances the utility methods for extracting nested properties from maps in the `DotUtils` class, improving support for dot-notated paths and type safety. It also updates related tests to verify the new behaviors and fixes import usages for test fixtures. The most significant changes are grouped below:

### DotUtils enhancements

* Refactored `mapFrom`, `listFrom`, and `arrayFrom` methods in `DotUtils` to support extraction from nested properties using dot-notated paths and improved type safety checks. Added a new typed variant `listFrom(Map<String, Object> source, String property, Class<T> clazz)` for extracting lists of a specific type. [[1]](diffhunk://#diff-56857aceaa8b2dd1f6a22e7a5a8c937069318a93ae3ae082706836b791221f36L36-R43) [[2]](diffhunk://#diff-56857aceaa8b2dd1f6a22e7a5a8c937069318a93ae3ae082706836b791221f36L52-R132)
* Introduced internal helper methods `getObjectFromSource` (for traversing nested map paths) and `convertToObjectArray` (for safely converting primitive arrays to `Object[]`).

### PathCommon improvement

* Improved property extraction logic in `PathCommon#getPropertyValue` to fall back to map access when the source object is a `Map` and the property exists, increasing robustness for mixed data types.