### PR TITLE
Added obfuscate feature for replacing source data with ****

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'temurin'
@@ -39,10 +39,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -42,9 +42,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Apache Maven Central
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -28,13 +28,13 @@ jobs:
             core.setOutput('base_ref', pr.data.base.ref);
             core.setOutput('head_sha', pr.data.head.sha);
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ steps.pr.outputs.head_sha }}
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'temurin'

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The `DotPathQL` is the core component of this project that allows you to extract
 
 - 🎯 **Selective Property Extraction**: Extract only the properties you need
 - 🚫 **Property Exclusion**: Exclude specific properties and return everything else
+- 🔐 **Property Obfuscation**: Replace sensitive property values with "****" while preserving structure
 - 🔍 **Deep Nested Support**: Navigate through multiple levels of object nesting
 - 📋 **Collection Handling**: Process Lists, Arrays, and other Collections
 - 🗺️ **Map Support**: Handle both simple and complex Map structures
@@ -25,16 +26,20 @@ The `DotPathQL` is the core component of this project that allows you to extract
 
 ## Quick Start
 
-## Install
-- Using the source code `mvn clean install`
-- Adding as a dependency - Maven
+### Library coordinates
 
+Maven
 ```xml
 <dependency>
   <groupId>ca.trackerforce</groupId>
   <artifactId>dot-path-ql</artifactId>
   <version>${dot-path-ql.version}</version>
 </dependency>
+```
+
+Gradle
+```groovy
+implementation 'ca.trackerforce:dot-path-ql:${dot-path-ql.version}'
 ```
 
 ### Filter Usage
@@ -56,6 +61,17 @@ Map<String, Object> result = new DotPathQL().exclude(userObject, List.of(
     "password",
     "ssn",
     "address.country"
+));
+```
+
+### Obfuscate Usage
+
+```java
+// Obfuscate specific properties by replacing their values with "****"
+Map<String, Object> result = new DotPathQL().obfuscate(userObject, List.of(
+    "password",
+    "ssn",
+    "creditCard.number"
 ));
 ```
 
@@ -176,6 +192,34 @@ List<String> reportFields = List.of(
     "orders.date",
     "orders.products.category"
 );
+```
+
+### Data Obfuscation for Security
+Mask sensitive information while maintaining data structure for logging, debugging, or sharing with third parties:
+
+```java
+// Obfuscate sensitive fields while keeping the structure intact
+List<String> sensitiveFields = List.of(
+    "password",
+    "ssn", 
+    "creditCard.number",
+    "bankAccount.accountNumber",
+    "personalInfo.phoneNumber"
+);
+
+Map<String, Object> obfuscatedData = doPathQl.obfuscate(userObject, sensitiveFields);
+
+// Result preserves structure but replaces sensitive values with "****"
+// {
+//   "username": "john_doe",
+//   "password": "****",
+//   "ssn": "****",
+//   "creditCard": {
+//     "number": "****",
+//     "expiryDate": "12/25"
+//   },
+//   "email": "john@example.com"
+// }
 ```
 
 ## JSON Output

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ca.trackerforce</groupId>
     <artifactId>dot-path-ql</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
 
     <name>dot-path-ql</name>
     <description>dotPathQL allows object attribute filtering</description>

--- a/src/main/java/ca/trackerforce/DotPathQL.java
+++ b/src/main/java/ca/trackerforce/DotPathQL.java
@@ -18,6 +18,7 @@ public class DotPathQL {
 
 	private final DotPath pathFilter;
 	private final DotPath pathExclude;
+	private final DotPath pathObfuscate;
 	private final DotPrinter pathPrinter;
 
 	/**
@@ -26,6 +27,7 @@ public class DotPathQL {
 	public DotPathQL() {
 		pathFilter = DotPathFactory.buildFilter();
 		pathExclude = DotPathFactory.buildExclude();
+		pathObfuscate = DotPathFactory.buildObfuscate();
 		pathPrinter = DotPathFactory.buildPrinter(2);
 	}
 
@@ -59,6 +61,20 @@ public class DotPathQL {
 	}
 
 	/**
+	 * Obfuscates the given source object based on the specified paths.
+	 * The paths can include nested properties, collections, and arrays.
+	 * Also supports grouped paths syntax like "parent[child1.prop,child2.prop]"
+	 *
+	 * @param <T>         the type of the source object
+	 * @param source      the source object to obfuscate
+	 * @param obfuscatePaths the list of paths to obfuscate
+	 * @return a map containing the obfuscated properties
+	 */
+	public <T> Map<String, Object> obfuscate(T source, List<String> obfuscatePaths) {
+		return pathObfuscate.run(source, obfuscatePaths);
+	}
+
+	/**
 	 * Adds default filter paths that will be included in every filtering operation.
 	 *
 	 * @param paths the list of default filter paths to add
@@ -74,6 +90,15 @@ public class DotPathQL {
 	 */
 	public void addDefaultExcludePaths(List<String> paths) {
 		pathExclude.addDefaultPaths(paths);
+	}
+
+	/**
+	 * Adds default obfuscate paths that will be included in every obfuscation operation.
+	 *
+	 * @param paths the list of default obfuscate paths to add
+	 */
+	public void addDefaultObfuscatePaths(List<String> paths) {
+		pathObfuscate.addDefaultPaths(paths);
 	}
 
 	/**

--- a/src/main/java/ca/trackerforce/DotUtils.java
+++ b/src/main/java/ca/trackerforce/DotUtils.java
@@ -66,6 +66,8 @@ public class DotUtils {
 	 *
 	 * @param source   the source map
 	 * @param property the property to extract or a dot-notated path for nested properties
+	 * @param clazz    the class type of the list elements
+	 * @param <T> the type of the list elements
 	 * @return the extracted list of maps or an empty list if not found
 	 * @throws ClassCastException if the property is not a list of maps
 	 */
@@ -132,5 +134,3 @@ public class DotUtils {
 		return result;
 	}
 }
-
-

--- a/src/main/java/ca/trackerforce/path/DotPathFactory.java
+++ b/src/main/java/ca/trackerforce/path/DotPathFactory.java
@@ -30,6 +30,17 @@ public class DotPathFactory {
 	}
 
 	/**
+	 * Builds and returns a new instance of PathExclude configured for obfuscation mode.
+	 *
+	 * @return a new PathExclude instance with obfuscation enabled
+	 */
+	public static PathExclude buildObfuscate() {
+		PathExclude pathExclude = new PathExclude();
+		pathExclude.setObfuscateMode(true);
+		return pathExclude;
+	}
+
+	/**
 	 * Builds and returns a new instance of PathPrinter with the specified indentation size.
 	 *
 	 * @param indentSize the number of spaces to use for indentation

--- a/src/main/java/ca/trackerforce/path/PathExclude.java
+++ b/src/main/java/ca/trackerforce/path/PathExclude.java
@@ -54,6 +54,10 @@ class PathExclude extends PathCommon {
 			return;
 		}
 
+		excludeFromNode(target, source, currentPath, node);
+	}
+
+	private void excludeFromNode(Map<String, Object> target, Object source, String currentPath, ExclusionNode node) {
 		for (String prop : getPropertyNames(source.getClass())) {
 			ExclusionNode childNode = node == null ? null : node.getChildren().get(prop);
 			if (childNode != null && childNode.isExcludeSelf() && childNode.getChildren().isEmpty()) {

--- a/src/main/java/ca/trackerforce/path/PathExclude.java
+++ b/src/main/java/ca/trackerforce/path/PathExclude.java
@@ -10,6 +10,12 @@ class PathExclude extends PathCommon {
 		INSTANCE
 	}
 
+	private boolean obfuscateMode = false;
+
+	public void setObfuscateMode(boolean obfuscateMode) {
+		this.obfuscateMode = obfuscateMode;
+	}
+
 	public <T> Map<String, Object> execute(T source, List<String> excludePaths) {
 		Map<String, Object> result = new LinkedHashMap<>();
 		excludePaths.addAll(0, defaultPaths);
@@ -51,6 +57,9 @@ class PathExclude extends PathCommon {
 		for (String prop : getPropertyNames(source.getClass())) {
 			ExclusionNode childNode = node == null ? null : node.getChildren().get(prop);
 			if (childNode != null && childNode.isExcludeSelf() && childNode.getChildren().isEmpty()) {
+				if (obfuscateMode) {
+					target.put(prop, "****");
+				}
 				continue;
 			}
 
@@ -69,6 +78,9 @@ class PathExclude extends PathCommon {
 			ExclusionNode childNode = node == null ? null : node.getChildren().get(key);
 
 			if (childNode != null && childNode.isExcludeSelf() && childNode.getChildren().isEmpty()) {
+				if (obfuscateMode) {
+					target.put(key, "****");
+				}
 				continue;
 			}
 

--- a/src/test/java/ca/trackerforce/ObfuscateTypeClassRecordTest.java
+++ b/src/test/java/ca/trackerforce/ObfuscateTypeClassRecordTest.java
@@ -1,0 +1,161 @@
+package ca.trackerforce;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ObfuscateTypeClassRecordTest {
+
+    DotPathQL dotPathQL = new DotPathQL();
+
+    static Stream<Arguments> userDetailProvider() {
+        return Stream.of(
+                Arguments.of("Record type", ca.trackerforce.fixture.record.UserDetail.of()),
+                Arguments.of("Class type", ca.trackerforce.fixture.clazz.UserDetail.of())
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("userDetailProvider")
+    void shouldObfuscateSimpleNestedField(String implementation, Object userDetail) {
+		// When
+        var result = dotPathQL.obfuscate(userDetail, List.of("orders.orderId"));
+
+		// Then
+		var orders = DotUtils.listFrom(result, "orders");
+        assertNotNull(orders);
+        assertEquals(2, orders.size());
+		assertEquals("****", orders.get(0).get("orderId"));
+		assertEquals("****", orders.get(1).get("orderId"));
+    }
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("userDetailProvider")
+	void shouldObfuscateMultipleSameBranch(String implementation, Object userDetail) {
+		// When
+		var result = dotPathQL.obfuscate(userDetail, List.of(
+				"address.street",
+				"address.city"
+		));
+
+		// Then
+		var address = DotUtils.mapFrom(result, "address");
+		assertNotNull(address);
+		assertEquals("****", address.get("street"));
+		assertEquals("****", address.get("city"));
+		assertTrue(address.containsKey("zipCode"));
+		assertTrue(address.containsKey("country"));
+	}
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("userDetailProvider")
+    void shouldObfuscateMultipleDifferentBranches(String implementation, Object userDetail) {
+		// When
+        var result = dotPathQL.obfuscate(userDetail, List.of(
+                "address.street",
+                "orders.products.description",
+                "additionalInfo.lastLogin"
+        ));
+
+		// Then
+        var address = DotUtils.mapFrom(result, "address");
+        assertNotNull(address);
+		assertEquals("****", address.get("street"));
+		assertTrue(address.containsKey("city"));
+
+        // orders products have no description
+        var orders = DotUtils.listFrom(result, "orders");
+        var firstOrderProducts = DotUtils.listFrom(orders.get(0), "products");
+		assertNotNull(firstOrderProducts);
+		assertEquals(2, firstOrderProducts.size());
+		assertEquals("****", firstOrderProducts.get(0).get("description"));
+		assertEquals("****", firstOrderProducts.get(1).get("description"));
+
+        // additionalInfo without lastLogin
+        var addInfo = DotUtils.mapFrom(result, "additionalInfo");
+        assertNotNull(addInfo);
+		assertEquals("****", addInfo.get("lastLogin"));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("userDetailProvider")
+    void shouldObfuscateGroupedPaths(String implementation, Object userDetail) {
+		// When
+        var result = dotPathQL.obfuscate(userDetail, List.of("locations[home.street,work.city]"));
+
+		// Then
+        var locations = DotUtils.mapFrom(result, "locations");
+        assertNotNull(locations);
+
+        var home = DotUtils.mapFrom(locations, "home");
+        assertNotNull(home);
+		assertEquals("****", home.get("street"));
+		assertTrue(home.containsKey("city"));
+
+        var work = DotUtils.mapFrom(locations, "work");
+		assertNotNull(work);
+		assertEquals("****", work.get("city"));
+		assertTrue(work.containsKey("street"));
+    }
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("userDetailProvider")
+	void shouldAddDefaultObfuscatePaths(String implementation, Object userDetail) {
+		// When
+		dotPathQL.addDefaultObfuscatePaths(List.of("username"));
+		var result = dotPathQL.obfuscate(userDetail, List.of("address.city"));
+
+		// Then
+		assertEquals("****", result.get("username"));
+		var address = DotUtils.mapFrom(result, "address");
+		assertNotNull(address);
+		assertEquals("****", address.get("city"));
+		assertTrue(address.containsKey("street"));
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("userDetailProvider")
+	void shouldObfuscateSimpleNestedFieldFromMapSource(String implementation, Object userDetail) {
+		// When
+		var source = dotPathQL.toMap(userDetail); // Convert to Map for testing
+		var result = dotPathQL.obfuscate(source, List.of("orders.orderId"));
+
+		// Then
+		var orders = DotUtils.listFrom(result, "orders");
+		assertNotNull(orders);
+		assertEquals(2, orders.size());
+		assertEquals("****", orders.get(0).get("orderId"));
+		assertEquals("****", orders.get(1).get("orderId"));
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("userDetailProvider")
+	void shouldNotObfuscateWhenPathNotExists(String implementation, Object userDetail) {
+		// When
+		var source = dotPathQL.toMap(userDetail); // Convert to Map for testing
+		var result = dotPathQL.obfuscate(source, List.of(
+				"invalidProperty" // Non-existent property
+		));
+
+		// Then
+		assertNotNull(result);
+		assertEquals(source, result); // Should be unchanged
+	}
+
+	@Test
+	void shouldReturnEmptyMapWhenSourceIsNull() {
+		// When
+		var result = dotPathQL.obfuscate(null, List.of("orders.orderId"));
+
+		// Then
+		assertNotNull(result);
+		assertTrue(result.isEmpty());
+	}
+
+}

--- a/src/test/java/ca/trackerforce/ObfuscateTypeClassTest.java
+++ b/src/test/java/ca/trackerforce/ObfuscateTypeClassTest.java
@@ -5,24 +5,25 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class ExcludeTypeClassTest {
+class ObfuscateTypeClassTest {
 
 	DotPathQL dotPathQL = new DotPathQL();
 
 	@Test
-	void shouldExcludeAndNotReturnPrivateAttributes() {
+	void shouldObfuscateAndNotReturnPrivateAttributes() {
 		// Given
 		var customer = Customer.of();
 
 		// When
-		var result = dotPathQL.exclude(customer, List.of("email"));
+		var result = dotPathQL.obfuscate(customer, List.of("email"));
 
 		// Then
 		var metadata = DotUtils.mapFrom(result, "metadata"); // private field
 		assertEquals(0, metadata.size());
 
-		assertFalse(result.containsKey("email"));
+		var email = result.get("email");
+		assertEquals("****", email);
 	}
 }


### PR DESCRIPTION
This pull request adds a new property obfuscation feature to the `DotPathQL` library, allowing users to mask sensitive data fields (such as passwords or SSNs) with "****" while preserving the structure of the original object. The update includes changes to the core implementation, factory methods, and test coverage, as well as documentation enhancements in the `README.md`.

**New Feature: Property Obfuscation**

- Added an `obfuscate` method to `DotPathQL`, enabling users to specify paths whose values should be replaced with "****".
- Introduced support for default obfuscation paths via `addDefaultObfuscatePaths`.
- Updated the `PathExclude` class and factory to support obfuscation mode, ensuring the same filtering logic can be reused for masking values [[1]](diffhunk://#diff-b62cfafa67e930de4a8ebe3a0e360a127d3758b6f931c9a1685056771ca0bc80R32-R42) [[2]](diffhunk://#diff-b49243e2617bd093dfa9f74ce3b242b726c67d38d2ac20f786923a35a6e48d7bR13-R18) [[3]](diffhunk://#diff-b49243e2617bd093dfa9f74ce3b242b726c67d38d2ac20f786923a35a6e48d7bR60-R62) [[4]](diffhunk://#diff-b49243e2617bd093dfa9f74ce3b242b726c67d38d2ac20f786923a35a6e48d7bR81-R83).

**Other Improvements**

- Minor JavaDoc and parameter annotation improvements for utility methods [[1]](diffhunk://#diff-56857aceaa8b2dd1f6a22e7a5a8c937069318a93ae3ae082706836b791221f36R69-R70) [[2]](diffhunk://#diff-56857aceaa8b2dd1f6a22e7a5a8c937069318a93ae3ae082706836b791221f36L135-L136).