### PR TITLE
chore(deps): bump test and plugin deps

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Setup Java
         uses: actions/setup-java@v5
@@ -51,7 +51,7 @@ jobs:
         run: mvn -version
 
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-m2-${{ matrix.java }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         if: env.SONAR_TOKEN != ''
-        run: mvn -B clean verify -Pcoverage,sonar -Dsonar.token=${{ secrets.SONAR_TOKEN }}
+        run: mvn -B clean verify -Pcoverage,sonar -Dsonar.token=$SONAR_TOKEN
 
   build-test:
     name: Build & Test - JDK ${{ matrix.java }} on ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Setup Java
         uses: actions/setup-java@v5
@@ -27,7 +27,7 @@ jobs:
         run: mvn -version
 
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-m2-${{ matrix.java }}
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Set up Apache Maven Central
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -43,10 +43,11 @@ jobs:
       - name: Build/Test & SonarCloud Scan
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          PR_ID: ${{ inputs.pr_id }}
         if: env.SONAR_TOKEN != ''
         run: |
           mvn -B clean verify -Pcoverage,sonar \
-            -Dsonar.token=${{ secrets.SONAR_TOKEN }} \
-            -Dsonar.pullrequest.key=${{ inputs.pr_id }} \
+            -Dsonar.token=$SONAR_TOKEN \
+            -Dsonar.pullrequest.key=$PR_ID \
             -Dsonar.pullrequest.branch=${{ steps.pr.outputs.head_ref }} \
             -Dsonar.pullrequest.base=${{ steps.pr.outputs.base_ref }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Get PR details
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -28,7 +28,7 @@ jobs:
             core.setOutput('base_ref', pr.data.base.ref);
             core.setOutput('head_sha', pr.data.head.sha);
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ steps.pr.outputs.head_sha }}
           fetch-depth: 0

--- a/pom.xml
+++ b/pom.xml
@@ -47,18 +47,18 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- test -->
-        <junit-jupiter.version>5.13.4</junit-jupiter.version>
-        <lombok.version>1.18.30</lombok.version>
+        <junit-jupiter.version>6.1.2</junit-jupiter.version>
+        <lombok.version>1.18.46</lombok.version>
 
         <!-- plugins -->
-        <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
-        <sonar-maven-plugin.version>3.11.0.3922</sonar-maven-plugin.version>
-        <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
-        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-        <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
-        <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
+        <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
+        <sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+        <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
+        <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
+        <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
-        <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
 
         <!-- sonar -->
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>


### PR DESCRIPTION
This pull request primarily updates dependencies and GitHub Actions workflows to use the latest versions, improving security, compatibility, and build reliability. The most important changes are grouped below:

**GitHub Actions Workflow Updates:**

* Updated `actions/checkout` from v5 to v7 in `.github/workflows/master.yml`, `.github/workflows/release.yml`, and `.github/workflows/sonar.yml` for all jobs to use the latest features and fixes. [[1]](diffhunk://#diff-38ee08b0d1916cb5b9d8a093e986366eaafd908bc1f516f4fced0033c155d842L15-R15) [[2]](diffhunk://#diff-38ee08b0d1916cb5b9d8a093e986366eaafd908bc1f516f4fced0033c155d842L42-R42) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L18-R18) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L45-R45) [[5]](diffhunk://#diff-9a1c250ec072fc76ad44435cd9462d5693ea81f304d650922d3c2792bef267c2L31-R31)
* Updated `actions/cache` from v4 to v5 in `.github/workflows/master.yml` and `.github/workflows/release.yml` to improve caching reliability and performance. [[1]](diffhunk://#diff-38ee08b0d1916cb5b9d8a093e986366eaafd908bc1f516f4fced0033c155d842L54-R54) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L30-R30)
* Updated `actions/github-script` from v7 to v9 in `.github/workflows/sonar.yml` for enhanced scripting capabilities and bug fixes.

**Maven and Plugin Dependency Updates:**

* Upgraded several Maven plugin and library versions in `pom.xml`, including `junit-jupiter` (5.13.4 → 6.1.2), `lombok` (1.18.30 → 1.18.46), `jacoco-maven-plugin`, `sonar-maven-plugin`, `maven-compiler-plugin`, and others, ensuring compatibility with the latest tools and improved build/test quality.